### PR TITLE
fix 2d ply output for polymesh

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,12 @@ All notable changes to this project will be documented in this file.
 The format is based on `Keep a Changelog`_,
 and this project adheres to `Semantic Versioning`_.
 
+`Unreleased`_
+--------------------------
+Fixed
+'''''''
+- PLY file format in 2D.
+
 `1.4.2`_ - 2020-11-3
 --------------------------
 Fixed

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 The format is based on `Keep a Changelog`_,
 and this project adheres to `Semantic Versioning`_.
 
-`Unreleased`_
+`1.4.3`_ - 2020-11-11
 --------------------------
 Fixed
 '''''''
@@ -184,7 +184,8 @@ Added
 
 .. LINKS
 
-.. _`Unreleased`: https://github.com/kip-hart/MicroStructPy/compare/v1.4.2...HEAD
+.. _`Unreleased`: https://github.com/kip-hart/MicroStructPy/compare/v1.4.3...HEAD
+.. _`1.4.3`: https://github.com/kip-hart/MicroStructPy/compare/v1.4.2...v1.4.3
 .. _`1.4.2`: https://github.com/kip-hart/MicroStructPy/compare/v1.4.1...v1.4.2
 .. _`1.4.1`: https://github.com/kip-hart/MicroStructPy/compare/v1.4.0...v1.4.1
 .. _`1.4.0`: https://github.com/kip-hart/MicroStructPy/compare/v1.3.5...v1.4.0

--- a/src/microstructpy/__init__.py
+++ b/src/microstructpy/__init__.py
@@ -4,4 +4,4 @@ import microstructpy.meshing
 import microstructpy.seeding
 import microstructpy.verification
 
-__version__ = '1.4.2'
+__version__ = '1.4.3'

--- a/src/microstructpy/meshing/polymesh.py
+++ b/src/microstructpy/meshing/polymesh.py
@@ -287,33 +287,24 @@ class PolyMesh(object):
             ply += 'element vertex ' + str(nv) + '\n'
             ply += ''.join(['property float32 ' + a + '\n' for a in axes])
             if nd == 2:
-                ply += 'element face {}\n'.format(nr)
-                ply += 'property list uchar int vertex_indices\n'
-
-                ply += 'element edge {}\n'.format(nf)
-                ply += 'property int vertex1\n'
-                ply += 'property int vertex2\n'
+                n_faces = nr
             else:
-                ply += 'element face {}\n'.format(nf)
-                ply += 'property list uchar int vertex_index\n'
+                n_faces = nf
+            ply += 'element face {}\n'.format(n_faces)
+            ply += 'property list uchar int vertex_indices\n'
             ply += 'end_header\n'
 
             # vertices
             ply += ''.join([' '.join(['{: e}'.format(x) for x in pt]) + '\n'
                             for pt in pts])
 
-            if nd == 2:  # facets -> edges, regions -> faces
-                # faces
+            if nd == 2:  # regions -> faces
                 facets = np.array(self.facets)
                 ply += ''.join([str(len(r)) + ''.join([' ' + str(kp) for kp in
                                                        kp_loop(facets[r])])
                                 + '\n' for r in self.regions])
 
-                # edges
-                ply += ''.join([' '.join([str(kp) for kp in f]) + '\n'
-                                for f in facets])
-            else:  # facets -> faces, regions not output (arbitrary polyhedra)
-                # faces
+            else:  # facets -> faces
                 ply += ''.join([str(len(f)) + ''.join([' ' + str(kp)
                                                        for kp in f])
                                 + '\n' for f in self.facets])

--- a/src/microstructpy/meshing/polymesh.py
+++ b/src/microstructpy/meshing/polymesh.py
@@ -298,6 +298,7 @@ class PolyMesh(object):
             ply += ''.join([' '.join(['{: e}'.format(x) for x in pt]) + '\n'
                             for pt in pts])
 
+            # faces
             if nd == 2:  # regions -> faces
                 facets = np.array(self.facets)
                 ply += ''.join([str(len(r)) + ''.join([' ' + str(kp) for kp in


### PR DESCRIPTION
## PR Summary
### Purpose
This PR addresses the issue of edge-only output to ply files, raised in #34.

### Approach
This change addresses the problem by removing the edge output and defining the regions as vertex loops.

## PR Checklist
- [x] All ``tox`` commands succeed
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Has pytest style unit tests

## Closing Issues
<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
Fixes #34


<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  the style guides for Sphinx and NumPy docstrings.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
