### PR TITLE
Plot default hotfix

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,13 @@ All notable changes to this project will be documented in this file.
 The format is based on `Keep a Changelog`_,
 and this project adheres to `Semantic Versioning`_.
 
+`1.4.8`_ - 2021-05-13
+--------------------------
+Fixed
+'''''''
+- Default behavior of ``cli.*_plot`` functions when ``plot_files`` is not
+  specified.
+
 `1.4.7`_ - 2021-02-07
 --------------------------
 Changed
@@ -218,7 +225,8 @@ Added
 
 .. LINKS
 
-.. _`Unreleased`: https://github.com/kip-hart/MicroStructPy/compare/v1.4.7...HEAD
+.. _`Unreleased`: https://github.com/kip-hart/MicroStructPy/compare/v1.4.8...HEAD
+.. _`1.4.8`: https://github.com/kip-hart/MicroStructPy/compare/v1.4.7...v1.4.8
 .. _`1.4.7`: https://github.com/kip-hart/MicroStructPy/compare/v1.4.6...v1.4.7
 .. _`1.4.6`: https://github.com/kip-hart/MicroStructPy/compare/v1.4.5...v1.4.6
 .. _`1.4.5`: https://github.com/kip-hart/MicroStructPy/compare/v1.4.4...v1.4.5

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,7 +10,7 @@ and this project adheres to `Semantic Versioning`_.
 --------------------------
 Fixed
 '''''''
-- Default behavior of ``cli.*_plot`` functions when ``plot_files`` is not
+- Default behavior of ``cli.plot_*`` functions when ``plot_files`` is not
   specified.
 
 `1.4.7`_ - 2021-02-07

--- a/LICENSE.rst
+++ b/LICENSE.rst
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019-2020 Georgia Tech Research Corporation
+Copyright (c) 2019-2021 Georgia Tech Research Corporation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -25,7 +25,7 @@ import microstructpy
 # -- Project information -----------------------------------------------------
 
 project = 'MicroStructPy'
-copyright = '2019-2020, Georgia Tech Research Corporation'
+copyright = '2019-2021, Georgia Tech Research Corporation'
 author = 'Kenneth Hart'
 
 # The short X.Y version

--- a/src/microstructpy/__init__.py
+++ b/src/microstructpy/__init__.py
@@ -4,4 +4,4 @@ import microstructpy.meshing
 import microstructpy.seeding
 import microstructpy.verification
 
-__version__ = '1.4.7'
+__version__ = '1.4.8'

--- a/src/microstructpy/cli.py
+++ b/src/microstructpy/cli.py
@@ -645,7 +645,7 @@ def plot_seeds(seeds, phases, domain, plot_files=[], plot_axes=True,
             for more details.
         domain (from :mod:`microstructpy.geometry`): Domain geometry.
         plot_files (list): *(optional)* List of files to save the output plot.
-            Defaults to saving the plot to ``polymesh.png``.
+            Defaults to saving the plot to ``seeds.png``.
         plot_axes (bool): *(optional)* Flag to turn the axes on or off.
             True shows the axes, False removes them. Defaults to True.
         color_by (str): *(optional)* {'material' | 'seed number' |
@@ -660,7 +660,7 @@ def plot_seeds(seeds, phases, domain, plot_files=[], plot_axes=True,
 
     """
     if not plot_files:
-        return
+        plot_files = ['seeds.png']
 
     phase_names = []
     given_names = False
@@ -778,7 +778,7 @@ def plot_poly(pmesh, phases, plot_files=['polymesh.png'], plot_axes=True,
 
     """
     if not plot_files:
-        return
+        plot_files = ['polymesh.png']
 
     n_dim = len(pmesh.points[0])
 
@@ -897,7 +897,7 @@ def plot_tri(tmesh, phases, seeds, pmesh, plot_files=[], plot_axes=True,
         seeds (SeedList): List of seed geometries.
         pmesh (PolyMesh): Polygonal mesh from which ``tmesh`` was generated.
         plot_files (list): *(optional)* List of files to save the output plot.
-            Defaults to saving the plot to ``polymesh.png``.
+            Defaults to saving the plot to ``trimesh.png``.
         plot_axes (bool): *(optional)* Flag to turn the axes on or off.
             True shows the axes, False removes them. Defaults to True.
         color_by (str): *(optional)* {'material' | 'seed number' |
@@ -912,7 +912,7 @@ def plot_tri(tmesh, phases, seeds, pmesh, plot_files=[], plot_axes=True,
 
     """
     if not plot_files:
-        return
+        plot_files = ['trimesh.png']
 
     n_dim = len(tmesh.points[0])
 


### PR DESCRIPTION
## PR Summary
### Purpose
Align the default behavior of `cli.plot_*()` without `plot_files` specified to match documentation.

### Approach
Previously, the function would quit if `plot_files` was unspecified. Now, it will do the stated default behavior, create a png of the plot.

## PR Checklist
- [ ] All ``tox`` commands succeed
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Has pytest style unit tests