### PR TITLE
fix for amorphous and void phases in gmsh

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,12 @@ All notable changes to this project will be documented in this file.
 The format is based on `Keep a Changelog`_,
 and this project adheres to `Semantic Versioning`_.
 
+`1.4.9`_ - 2021-05-13
+--------------------------
+Fixed
+'''''''
+- Bug in gmsh for amorphous and void phases.
+
 `1.4.8`_ - 2021-05-13
 --------------------------
 Fixed
@@ -225,7 +231,8 @@ Added
 
 .. LINKS
 
-.. _`Unreleased`: https://github.com/kip-hart/MicroStructPy/compare/v1.4.8...HEAD
+.. _`Unreleased`: https://github.com/kip-hart/MicroStructPy/compare/v1.4.9...HEAD
+.. _`1.4.9`: https://github.com/kip-hart/MicroStructPy/compare/v1.4.8...v1.4.9
 .. _`1.4.8`: https://github.com/kip-hart/MicroStructPy/compare/v1.4.7...v1.4.8
 .. _`1.4.7`: https://github.com/kip-hart/MicroStructPy/compare/v1.4.6...v1.4.7
 .. _`1.4.6`: https://github.com/kip-hart/MicroStructPy/compare/v1.4.5...v1.4.6

--- a/src/microstructpy/__init__.py
+++ b/src/microstructpy/__init__.py
@@ -4,4 +4,4 @@ import microstructpy.meshing
 import microstructpy.seeding
 import microstructpy.verification
 
-__version__ = '1.4.8'
+__version__ = '1.4.9'

--- a/src/microstructpy/cli.py
+++ b/src/microstructpy/cli.py
@@ -950,7 +950,7 @@ def plot_tri(tmesh, phases, seeds, pmesh, plot_files=[], plot_axes=True,
     invis_regions = set(range(-6, 0))
     f_front = set([i for i, fn in enumerate(pmesh.facet_neighbors)
                    if min(fn) < 0])
-    while f_front:
+    while f_front and n_dim > 2:
         new_front = set()
         for f in f_front:
             neighs = set(pmesh.facet_neighbors[f])
@@ -963,6 +963,8 @@ def plot_tri(tmesh, phases, seeds, pmesh, plot_files=[], plot_axes=True,
                     vis_regions.add(n)
         new_front -= f_front
         f_front = new_front
+    if n_dim < 3:
+        vis_regions = set(range(len(pmesh.regions)))
 
     # Determine facet colors based on visibility
     seed_colors = _seed_colors(seeds, phases, color_by, colormap)


### PR DESCRIPTION
## PR Summary
### Purpose
This PR resolves an issue with amorphous and void phases in the gmsh output.

For example 1, switching to gmsh created a TriMesh that look like this:
![trimesh_was](https://user-images.githubusercontent.com/41959581/118292662-df5e4480-b4a6-11eb-8de9-9c2532c266ca.png)

After the switch, the mesh looks like this:
![trimesh_is](https://user-images.githubusercontent.com/41959581/118292691-e422f880-b4a6-11eb-9b9f-ec60df68ef01.png)


### Approach
The regions and facets of the PolyMesh are all considered physical in the gmsh input geometry. Once the mesh has been created, elements in void regions are removed and facets between amorphous regions of the same phase are removed.

The boundaries between amorphous regions are preserved in the TriMesh. This is an artifact of how a geometry is defined in gmsh. The image below shows all the boundaries between regions. These boundaries are apparent in the TriMesh output.
![polymesh](https://user-images.githubusercontent.com/41959581/118293239-71fee380-b4a7-11eb-9c5b-f579dff1fdd2.png)


## PR Checklist
- [ ] All ``tox`` commands succeed
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Has pytest style unit tests
