### PR TITLE
gmsh multisphere

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,12 @@ All notable changes to this project will be documented in this file.
 The format is based on `Keep a Changelog`_,
 and this project adheres to `Semantic Versioning`_.
 
+`1.4.10`_ - 2021-06-08
+--------------------------
+Fixed
+'''''''
+- Bug in gmsh for multi-circle seeds.
+
 `1.4.9`_ - 2021-05-14
 --------------------------
 Fixed
@@ -231,7 +237,8 @@ Added
 
 .. LINKS
 
-.. _`Unreleased`: https://github.com/kip-hart/MicroStructPy/compare/v1.4.9...HEAD
+.. _`Unreleased`: https://github.com/kip-hart/MicroStructPy/compare/v1.4.10...HEAD
+.. _`1.4.10`: https://github.com/kip-hart/MicroStructPy/compare/v1.4.9...v1.4.10
 .. _`1.4.9`: https://github.com/kip-hart/MicroStructPy/compare/v1.4.8...v1.4.9
 .. _`1.4.8`: https://github.com/kip-hart/MicroStructPy/compare/v1.4.7...v1.4.8
 .. _`1.4.7`: https://github.com/kip-hart/MicroStructPy/compare/v1.4.6...v1.4.7

--- a/src/microstructpy/__init__.py
+++ b/src/microstructpy/__init__.py
@@ -4,4 +4,4 @@ import microstructpy.meshing
 import microstructpy.seeding
 import microstructpy.verification
 
-__version__ = '1.4.9'
+__version__ = '1.4.10'

--- a/src/microstructpy/meshing/trimesh.py
+++ b/src/microstructpy/meshing/trimesh.py
@@ -938,9 +938,11 @@ def _call_gmsh(pmesh, phases, res, edge_res):
             loops = []
             surfs = []
             seed_facets = {}
+            seed_phases = {}
             for i, r in enumerate(pmesh.regions):
                 s = pmesh.seed_numbers[i]
                 seed_facets.setdefault(s, set()).symmetric_difference_update(r)
+                seed_phases[s] = pmesh.phase_numbers[i]
             for i in seed_facets:
                 region = list(seed_facets[i])
                 sorted_pairs = _sort_facets([pmesh.facets[f] for f in region])
@@ -963,7 +965,7 @@ def _call_gmsh(pmesh, phases, res, edge_res):
                 surfs.append(geom.add_plane_surface(loops[-1]))
                 lbl = 'seed-' + str(i)
                 geom.add_physical(surfs[-1], lbl)
-                p_num = pmesh.phase_numbers[i]
+                p_num = seed_phases[i]
                 mat_type = phases[p_num].get('material_type', 'solid')
                 if mat_type not in _misc.kw_void:
                     phys_seeds.append(lbl)


### PR DESCRIPTION
## PR Summary
### Purpose
This PR fixes a bug with multi-sphere voids in meshes created with gmsh.

The `elliptical_grains.xml` example, with gmsh and void ellipses, would be:

![trimesh_was](https://user-images.githubusercontent.com/41959581/121252301-d2e6c500-c875-11eb-88cf-307490b96d2c.png)

By fixing the bug, related to seed numbers vs region numbers, the result is now:

![trimesh_is_scaled](https://user-images.githubusercontent.com/41959581/121252602-32dd6b80-c876-11eb-8769-00d107ff99aa.png)


### Approach
Track phase numbers of seeds, not regions, in the `_call_gmsh` function.

## PR Checklist
- [ ] All ``tox`` commands succeed
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Has pytest style unit tests


<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  the style guides for Sphinx and NumPy docstrings.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
