### PR TITLE
force keypoints to be printed as ints

### DIFF
--- a/src/microstructpy/meshing/trimesh.py
+++ b/src/microstructpy/meshing/trimesh.py
@@ -304,9 +304,9 @@ class TriMesh(object):
             elem_type = {2: 'CPS3', 3: 'C3D4'}[n_dim]
 
             abaqus += '*Element, type=' + elem_type + '\n'
-            abaqus += ''.join([str(i + 1) + ''.join([', ' + str(kp + 1) for kp
-                                                     in elem]) + '\n' for
-                               i, elem in enumerate(self.elements)])
+            abaqus += ''.join([str(i + 1) + ''.join([', ' + str(int(kp) + 1)
+                                                     for kp in elm]) + '\n' for
+                               i, elm in enumerate(self.elements)])
 
             # Element sets - seed number
             elset_n_per = 16


### PR DESCRIPTION
## PR Summary
### Purpose
This PR resolves a bug in writing abaqus inp files. The TriMesh.write method would write out keypoint numbers as floats. This PR forces the method to write integers.

### Approach
In the nested for loop the writes elements, ``str(kp+1)`` was replaced with ``str(int(kp)+1)``.

## Closing Issues
<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
Fixes #58 


<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  the style guides for Sphinx and NumPy docstrings.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
