### PR TITLE
No Python 3.7

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.7'
+        python-version: '3.10'
     - name: Setup Linux Environment
       run: |
         sudo apt-get install libglu1

--- a/.github/workflows/python_package.yaml
+++ b/.github/workflows/python_package.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.8, 3.9, '3.10']
+        python-version: [3.8, 3.9, '3.10']
 
     steps:
     - uses: actions/checkout@v2

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,7 +7,7 @@ version: 2
 formats: all
 
 python:
-   version: 3.7
+   version: '3.10'
    install:
     - requirements: docs/requirements.txt
     - method: pip

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,7 +7,7 @@ version: 2
 formats: all
 
 python:
-   version: '3.10'
+   version: '3.8'
    install:
     - requirements: docs/requirements.txt
     - method: pip

--- a/README.rst
+++ b/README.rst
@@ -3,6 +3,7 @@ MicroStructPy - Microstructure Mesh Generation in Python
 
 |s-ci|
 |s-license|
+|s-versions|
 
 |s-doi1|
 |s-doi2|
@@ -199,6 +200,10 @@ advised by Prof. Julian Rimoli.
 .. |s-license| image:: https://img.shields.io/github/license/kip-hart/MicroStructPy
     :target: https://github.com/kip-hart/MicroStructPy/blob/master/LICENSE.rst
     :alt: License
+
+.. |s-versions| image:: https://img.shields.io/pypi/pyversions/microstructpy
+    :target: https://pypi.org/project/microstructpy/
+    :alt: Python Versions
 
 .. |s-doi1| image:: https://img.shields.io/badge/DOI-10.1016%2Fj.cma.2020.113242-blue
    :target: https://doi.org/10.1016/j.cma.2020.113242

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,6 @@
 gmsh==4.6.0.post2
 matplotlib==3.2.1
-numpy==1.17.3
+numpy==1.22.0
 pybind11==2.4.3
 sphinx==4.2.0
 sphinx-gallery==0.8.1

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 gmsh==4.6.0.post2
-matplotlib==3.2.1
+matplotlib==3.5.1
 numpy==1.22.0
 pybind11==2.4.3
 sphinx==4.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ matplotlib==3.3.4
 pybind11==2.4.3
 pygmsh==7.0.2
 MeshPy==2018.2.1
-numpy==1.21.6
+numpy==1.22.0
 pyquaternion==0.9.5
 pyvoro-mmalahe==1.3.3
 scipy==1.7.2

--- a/setup.py
+++ b/setup.py
@@ -57,9 +57,9 @@ setup(
         'Operating System :: MacOS :: MacOS X',
         'Operating System :: Microsoft :: Windows',
         'Operating System :: POSIX :: Linux',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'Topic :: Scientific/Engineering',
         'Topic :: Scientific/Engineering :: Mathematics',
         'Topic :: Scientific/Engineering :: Physics'


### PR DESCRIPTION
## PR Summary
Remove Python 3.7 as a supported version. The purpose of this PR is to increase the NumPy version to 1.21 or higher.
