### PR TITLE
change VTK output of rastermesh

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,10 +3,10 @@ matplotlib==3.3.4
 pybind11==2.4.3
 pygmsh==7.0.2
 MeshPy==2018.2.1
-numpy==1.22.0
+numpy==1.23.2
 pyquaternion==0.9.5
 pyvoro-mmalahe==1.3.3
-scipy==1.7.2
+scipy==1.9.1
 xmltodict==0.12.0
 tox==3.14.0
 lsq-ellipse==2.0.1

--- a/src/microstructpy/__init__.py
+++ b/src/microstructpy/__init__.py
@@ -4,4 +4,4 @@ import microstructpy.meshing
 import microstructpy.seeding
 import microstructpy.verification
 
-__version__ = '1.5.4'
+__version__ = '1.5.5'

--- a/src/microstructpy/meshing/trimesh.py
+++ b/src/microstructpy/meshing/trimesh.py
@@ -1019,6 +1019,8 @@ class RasterMesh(TriMesh):
         See the :ref:`s_tri_file_io` section of the :ref:`c_file_formats`
         guide for more details on these formats.
 
+        VTK files use the `RECTILINEAR_GRID` data type.
+
         Args:
             filename (str): The name of the file to write.
             format (str): {'abaqus' | 'txt' | 'vtk'}


### PR DESCRIPTION
## PR Summary
### Purpose
Update VTK output of rastermesh to use rectilinear_grid instead of unstructured_grid.

### Approach
Followed the file format for VTK

### Learning
http://www.princeton.edu/~efeibush/viscourse/vtk.pdf

## PR Checklist
- [ ] All ``tox`` commands succeed
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Has pytest style unit tests

## Closing Issues
<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
Relates to #73 


<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  the style guides for Sphinx and NumPy docstrings.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
