### PR TITLE
Add setuptools to requirements

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,13 @@ All notable changes to this project will be documented in this file.
 The format is based on `Keep a Changelog`_,
 and this project adheres to `Semantic Versioning`_.
 
+`Unreleased`_
+--------------------------
+Changed
+'''''''
+- Updated version numbers of dependencies per security report.
+
+
 `1.5.8`_ - 2023-08-25
 --------------------------
 Added

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,5 +2,6 @@ gmsh==4.11.1
 matplotlib==3.7.2
 numpy==1.24.4
 pybind11==2.4.3
+setuptools>=68.1.2
 sphinx==4.2.0
 sphinx-gallery==0.8.1

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,6 +2,6 @@ gmsh==4.11.1
 matplotlib==3.7.2
 numpy==1.24.4
 pybind11==2.4.3
-setuptools>=68.1.2
+setuptools>=65.5.1 
 sphinx==4.2.0
 sphinx-gallery==0.8.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ numpy==1.24.4
 pyquaternion==0.9.5
 pyvoro-mmalahe==1.3.4
 scipy==1.10.1
+setuptools>=68.1.2
 xmltodict==0.12.0
 tox==3.14.0
 lsq-ellipse==2.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ numpy==1.24.4
 pyquaternion==0.9.5
 pyvoro-mmalahe==1.3.4
 scipy==1.10.1
-setuptools>=68.1.2
+setuptools>=65.5.1 
 xmltodict==0.12.0
 tox==3.14.0
 lsq-ellipse==2.0.1

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ setup(
         'lsq-ellipse',
         'matplotlib>=3.4.0',
         'meshpy>=2018.2.1',
-        'numpy>=1.13.0',
+        'numpy>=1.22.2',
         'pygmsh>=7.0.2',
         'pyquaternion',
         'pyvoro-mmalahe>=1.3.4',  # install issue with pyvoro


### PR DESCRIPTION
## PR Summary
### Purpose
This PR adds setuptools as a build requirement to the requirements.txt files. It addresses PRs #80, #82, and #85.

### Approach
Requires at least the latest version of setuptools to be installed.
